### PR TITLE
Change class to render from article to li element in HTML document

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,8 +22,8 @@
       <h2>Records</h2>
     </header>
     <ul class="records">
-      <li>
-        <article class="record">
+      <li class="record">
+        <article>
           <span class="record-discount">discount</span>
           <img class="record-cover" src="" alt="">
           <div class="record-info">


### PR DESCRIPTION
Move class "record" from article element to li element to solve problem in W3C validator and Lighthouse that ul elements does not have li elements inside.