### PR TITLE
Bugfix/root selector

### DIFF
--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -8,7 +8,7 @@
 
 body {
   margin: 0;
-  font-family: "Montserrat", Arial, Helvetica, sans-serif;
+  font-family: Montserrat, sans-serif;
 }
 
 main {

--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -1,9 +1,9 @@
-* {
-  box-sizing: border-box;
-}
-
 :root {
   --main-color: #1f2c4d;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {


### PR DESCRIPTION
Put root pseudo-class first and remote double quotation marks from font-family and leave only sans-serif as font-family stack.